### PR TITLE
Update package.json license to reflect the LICENSE license

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
Changing the package.json license definition to match the Apache 2.0 license file included in the root of the repo.